### PR TITLE
Update lit.cfg.py

### DIFF
--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -73,6 +73,7 @@ if config.spirv_tools_have_spirv_val:
 else:
     config.substitutions.append(('spirv-val', ':'))
 
-if using_spirv_tools:
+env = config.environment
+if using_spirv_tools and ('LD_LIBRARY_PATH' in env):
     new_ld_library_path = os.path.pathsep.join((config.spirv_tools_lib_dir, config.environment['LD_LIBRARY_PATH']))
     config.environment['LD_LIBRARY_PATH'] = new_ld_library_path

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -73,7 +73,6 @@ if config.spirv_tools_have_spirv_val:
 else:
     config.substitutions.append(('spirv-val', ':'))
 
-env = config.environment
-if using_spirv_tools and ('LD_LIBRARY_PATH' in env):
-    new_ld_library_path = os.path.pathsep.join((config.spirv_tools_lib_dir, config.environment['LD_LIBRARY_PATH']))
-    config.environment['LD_LIBRARY_PATH'] = new_ld_library_path
+if using_spirv_tools:
+    llvm_config.with_system_environment('LD_LIBRARY_PATH')
+    llvm_config.with_environment('LD_LIBRARY_PATH', config.spirv_tools_lib_dir, append_path=True)


### PR DESCRIPTION
A KeyError gets triggered if the lit test is running in a machine which pre-installs spirv tools without setting LD_LIBRARY_PATH in env. It would be good to add a check before using.